### PR TITLE
Read Glad Giraffe player files correctly, fixes #232

### DIFF
--- a/starcheat/gui/mainwindow.py
+++ b/starcheat/gui/mainwindow.py
@@ -250,7 +250,7 @@ class MainWindow():
             items = []
             for x in getattr(self.player, "get_" + bag)():
                 if x is not None:
-                    items.append(ItemWidget(x["__content"], self.assets))
+                    items.append(ItemWidget(x["content"], self.assets))
                 else:
                     items.append(ItemWidget(None, self.assets))
 
@@ -344,7 +344,7 @@ class MainWindow():
         # save and show status
         logging.info("Writing file to disk")
         self.player.export_save(self.player.filename)
-        self.player.metadata.export_metadata(self.player.metadata.filename)
+        # self.player.metadata.export_metadata(self.player.metadata.filename) doesn't seem like anything gets written to metadata anymore
         self.update_title()
         self.ui.statusbar.showMessage("Saved " + self.player.filename, 3000)
         self.window.setWindowModified(False)
@@ -737,8 +737,8 @@ class MainWindow():
 
         for slot in range(len(bag)):
             item = bag[slot]
-            if item is not None and "__content" in item:
-                widget = ItemWidget(item["__content"], self.assets)
+            if item is not None and "content" in item:
+                widget = ItemWidget(item["content"], self.assets)
             else:
                 widget = ItemWidget(None, self.assets)
 

--- a/starcheat/saves.py
+++ b/starcheat/saves.py
@@ -359,9 +359,9 @@ def new_item(name, count=1, data={}):
         return None
 
     item = {
-        '__id': 'Item',
-        '__version': 5,
-        '__content': new_item_data(name, count, data)
+        'id': 'Item',
+        'version': 7,
+        'content': new_item_data(name, count, data)
     }
 
     return item
@@ -692,9 +692,9 @@ class PlayerSave():
         if slots is not None:
             main, glamor = slots
             if glamor is not None:
-                return glamor["__content"]
+                return glamor["content"]
             elif main is not None:
-                return main["__content"]
+                return main["content"]
 
     # here be setters
     def set_blueprints(self, blueprints):


### PR DESCRIPTION
"id", "version", and "content" no longer have __ in front of them. It
looks like metadata was changed to a single file for all characters. AI
and quests are in player files now (and starcheat will need to be
modified to deal with that).